### PR TITLE
Simplify readme

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -264,7 +264,7 @@ jobs:
   docs:
     name: Documentation
     needs: [docs-style]
-    runs-on: ubuntu-latest-8-cores
+    runs-on: public-ubuntu-latest-8-cores
     steps:
       - name: Login in Github Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -124,7 +124,10 @@ jobs:
 
       - name: Get Mechanical container logs
         if: always()
-        run: docker logs ${{ env.DOCKER_MECH_CONTAINER_NAME }} > mechanical_tests_log-${{ matrix.mechanical-version }}.txt 2>&1
+        run: |
+          docker logs ${{ env.DOCKER_MECH_CONTAINER_NAME }} > mechanical_tests_log-${{ matrix.mechanical-version }}.txt 2>&1
+          echo CONTAINER LOGS OUTPUT
+          cat mechanical_tests_log-${{ matrix.mechanical-version }}.txt
 
       - name: Upload container logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -283,6 +283,8 @@ jobs:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
           MECHANICAL_IMAGE: ${{ env.DOCKER_PACKAGE }}:${{ env.DOCKER_IMAGE_VERSION }}
         run: |
+          echo CPU info
+          lscpu
           docker pull ${{ env.MECHANICAL_IMAGE }}
           docker run --restart always --name ${{ env.DOCKER_MECH_CONTAINER_NAME }} -e ANSYSLMD_LICENSE_FILE=1055@${{ env.LICENSE_SERVER }} -p ${{ env.PYMECHANICAL_PORT }}:10000 ${{ env.MECHANICAL_IMAGE }} > log.txt &
           grep -q 'WB Initialize Done' <(timeout 60 tail -f log.txt)

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -128,6 +128,8 @@ jobs:
           docker logs ${{ env.DOCKER_MECH_CONTAINER_NAME }} > mechanical_tests_log-${{ matrix.mechanical-version }}.txt 2>&1
           echo CONTAINER LOGS OUTPUT
           cat mechanical_tests_log-${{ matrix.mechanical-version }}.txt
+          echo CPU info
+          lscpu
 
       - name: Upload container logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -69,7 +69,7 @@ jobs:
 
   tests:
     name: Testing and coverage - Mechanical ${{ matrix.mechanical-version }}
-    runs-on: ubuntu-latest-8-cores
+    runs-on: public-ubuntu-latest-8-cores
     needs: [smoke-tests]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -199,7 +199,7 @@ jobs:
 
   launch-tests:
     name: Launch testing and coverage
-    runs-on: ubuntu-latest-8-cores
+    runs-on: public-ubuntu-latest-8-cores
     container:
       image: ghcr.io/pyansys/pymechanical/mechanical:v23.2.0
       options: --entrypoint /bin/bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -69,7 +69,7 @@ jobs:
 
   tests:
     name: Testing and coverage - Mechanical ${{ matrix.mechanical-version }}
-    runs-on: public-ubuntu-latest-8-cores
+    runs-on: public-ubuntu-latest-16-cores
     needs: [smoke-tests]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -199,7 +199,7 @@ jobs:
 
   launch-tests:
     name: Launch testing and coverage
-    runs-on: public-ubuntu-latest-8-cores
+    runs-on: public-ubuntu-latest-16-cores
     container:
       image: ghcr.io/pyansys/pymechanical/mechanical:v23.2.0
       options: --entrypoint /bin/bash
@@ -264,7 +264,7 @@ jobs:
   docs:
     name: Documentation
     needs: [docs-style]
-    runs-on: public-ubuntu-latest-8-cores
+    runs-on: public-ubuntu-latest-16-cores
     steps:
       - name: Login in Github Container registry
         uses: docker/login-action@v2

--- a/README.rst
+++ b/README.rst
@@ -42,149 +42,19 @@ Mechanical within Python's ecosystem. It includes the ability to:
 
 Install the package
 -------------------
+Install PyMechanical using `pip` with::
 
-PyMechanical has three installation modes: user, developer, and offline.
+   pip install ansys-mechanical-core
 
-Install in user mode
-^^^^^^^^^^^^^^^^^^^^
-
-Before installing PyMechanical in user mode, ensure that you have the latest
-version of `pip`_ installed by running this command:
-
-.. code:: bash
-
-   python -m pip install -U pip
-
-Then, install PyMechanical by running this command:
-
-.. code:: bash
-
-   python -m pip install ansys-mechanical-core
-
-.. caution::
-
-    PyMechanical is currently hosted in a private PyPI repository. You must provide the index
-    URL to the private PyPI repository:
-
-    * Index URL: ``https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/``
-
-    If access to this package registry is needed, email `pyansys.core@ansys.com <mailto:pyansys.core@ansys.com>`_
-    to request access. The PyAnsys team can give you a read-only token to insert in ``${PRIVATE_PYPI_ACCESS_TOKEN}``.
-    Once you have this token, run this command:
-
-    .. code:: bash
-
-        pip install ansys-mechanical-core --index-url=https://${PRIVATE_PYPI_ACCESS_TOKEN}@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/
-
-Install in developer mode
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Installing PyMechanical in developer mode allows
-you to modify the source and enhance it.
-
-.. note::
-
-    Before contributing to the project, ensure that you are thoroughly familiar
-    with the `PyAnsys Developer's Guide`_.
-
-To install PyMechanical in developer mode, perform these steps:
-
-#. Clone the ``pymechanical`` repository:
-
-   .. code:: bash
-
-      git clone https://github.com/pyansys/pymechanical
-
-#. Access the ``pymechanical`` directory where the repository has been cloned:
-
-   .. code:: bash
-
-      cd pymechanical
-
-#. Create a clean Python virtual environment and activate it:
-
-   .. code:: bash
-
-      # Create a virtual environment
-      python -m venv .venv
-
-      # Activate it in a POSIX system
-      source .venv/bin/activate
-
-      # Activate it in Windows CMD environment
-      .venv\Scripts\activate.bat
-
-      # Activate it in Windows Powershell
-      .venv\Scripts\Activate.ps1
-
-#. Ensure that you have the latest required build system tools:
-
-   .. code:: bash
-
-      python -m pip install -U pip tox flit twine
-
-#. Install the project in editable mode:
-
-   .. code:: bash
-
-      # Install the minimum requirements
-      python -m pip install -e .
-
-      # Install the minimum + tests requirements
-      python -m pip install -e .[tests]
-
-      # Install the minimum + doc requirements
-      python -m pip install -e .[doc]
-
-      # Install all requirements
-      python -m pip install -e .[tests,doc]
-
-#. Verify your development installation:
-
-    .. code:: bash
-
-        tox
-
-
-Install in offline mode
-^^^^^^^^^^^^^^^^^^^^^^^
-
-If you lack an internet connection on your installation machine (or
-you do not have access to the private Ansys PyPI packages repository),
-you should install PyMechanical by downloading the wheelhouse
-archive from the `Releases Page <https://github.com/pyansys/pymechanical/releases>`_
-for your corresponding machine architecture.
-
-Each wheelhouse archive contains all the Python wheels necessary to install
-PyMechanical from scratch on Windows, Linux, and MacOS from Python 3.7 to 3.11.
-You can install a wheelhouse archive on an isolated system with a fresh Python
-installation or on a virtual environment.
-
-**On Linux**
-
-This code shows how to unzip the wheelhouse archive and install PyMechanical on
-Linux with Python 3.7:
-
-.. code:: bash
-
-    unzip ansys-mechanical-core-v0.7.dev3-wheelhouse-Linux-3.7.zip wheelhouse
-    pip install ansys-mechanical-core -f wheelhouse --no-index --upgrade --ignore-installed
-
-
-**On Windows**
-
-If you're on Windows with Python 3.9, unzip the wheelhouse archive to a wheelhouse
-directory and then install PyMechanical using the preceding command.
-
-Consider installing into a `virtual environment <https://docs.python.org/3/library/venv.html>`_.
+For more details, see `PyMechanical - Install the package <https://mechanical.docs.pyansys.com/version/stable/getting_started/index.html>`_
 
 Dependencies
 ------------
 
-You must have a licensed copy of Ansys Mechanical installed. When using an embedded instance,
-that installation must be runnable from the same computer as your Python program. When using
-a remote session, a connection to that session must be reachable from your Python program.
-
+You must have a licensed copy of `Ansys Mechanical <https://www.ansys.com/products/structures/ansys-mechanical>`_
+installed. When using an embedded instance, that installation must be runnable from the 
+same computer as your Python program. When using a remote session, a connection to that
+session must be reachable from your Python program.
 
 Getting started
 ---------------
@@ -239,86 +109,10 @@ and later. Here is an example:
    app = pymechanical.App()
    result = app.ExtAPI.DataModel.Project.ProjectDirectory
 
-Testing
--------
-
-This project takes advantage of `tox`_. This tool automates common
-development tasks (similar to Makefile), but it is oriented towards Python
-development.
-
-Using ``tox``
-^^^^^^^^^^^^^
-
-While Makefile has rules, ``tox`` has environments. In fact, ``tox`` creates its
-own virtual environment so that anything being tested is isolated from the project
-to guarantee the project's integrity.
-
-The following environment commands are provided:
-
-- **tox -e style**: Checks for coding style quality.
-- **tox -e py**: Checks for unit tests.
-- **tox -e py-coverage**: Checks for unit testing and code coverage.
-- **tox -e doc**: Checks for documentation-building process.
-
-
-Raw testing
-^^^^^^^^^^^
-
-If required, from the command line, you can call style commands like
-`black`_, `isort`_, and `flake8`_. You can also call unit testing commands like `pytest`_.
-However, running these commands do not guarantee that your project is being tested
-in an isolated environment, which is the reason why tools like ``tox`` exist.
-
-
-Using ``pre-commit``
-^^^^^^^^^^^^^^^^^^^^
-
-The style checks implemented for PyMechanical take advantage of `pre-commit`_.
-Developers are not forced but are encouraged to install this tool by running this
-command:
-
-.. code:: bash
-
-    python -m pip install pre-commit && pre-commit install
-
-
-Documentation
--------------
-
-For building documentation, you can run the usual rules provided in the
-`Sphinx`_ ``make`` file. Here is an example:
-
-.. code:: bash
-
-    #  build and view the doc from the POSIX system
-    make -C doc/ html && your_browser_name doc/html/index.html
-
-    # build and view the doc from CMD / PowerShell environment
-    .\doc\make.bat clean
-    .\doc\make.bat html
-    start .\doc\_build\html\index.html
-
-
-However, the recommended way of checking documentation integrity is to use
-``tox``:
-
-.. code:: bash
-
-    tox -e doc && your_browser_name .tox/doc_out/index.html
-
-
-Distributing
-------------
-
-If you would like to create either source or wheel files, start by installing
-the building requirements and then executing the build module:
-
-.. code:: bash
-
-    python -m pip install -U pip
-    python -m flit build
-    python -m twine check dist/*
-
+Testing and Development
+-----------------------
+If you would like to test or contribute to the development of PyMechanical, please visit
+`PyMechanical - Contributing <https://mechanical.docs.pyansys.com/version/stable/contributing.html>`_.
 
 .. LINKS AND REFERENCES
 .. _black: https://github.com/psf/black

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,6 +53,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinx_design",
     "sphinx_gallery.gen_gallery",
     "sphinxemoji.sphinxemoji",
 ]

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -239,6 +239,12 @@ This way, it's not possible for you to push code that fails the style checks::
   flake8...................................................................Passed
   codespell................................................................Passed
 
+
 .. LINKS AND REFERENCES
+.. _PyAnsys Developer's Guide: https://dev.docs.pyansys.com/
 .. _PyTest: https://docs.pytest.org/en/stable/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _black: https://github.com/psf/black
+.. _flake8: https://flake8.pycqa.org/en/latest/
+.. _isort: https://github.com/PyCQA/isort
 .. _tox: https://tox.wiki/

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -38,19 +38,32 @@ To install PyMechanical in developer mode, perform these steps:
 
 #. Create a clean Python virtual environment and activate it:
 
-   .. code:: bash
+.. tab-set::
 
-      # Create a virtual environment
-      python -m venv .venv
+    .. tab-item:: Windows
 
-      # Activate it in a POSIX system
-      source .venv/bin/activate
+        .. tab-set::
 
-      # Activate it in Windows CMD environment
-      .venv\Scripts\activate.bat
+            .. tab-item:: CMD
 
-      # Activate it in Windows Powershell
-      .venv\Scripts\Activate.ps1
+                .. code-block:: text
+
+                    python -m venv .venv
+                    .venv\Scripts\activate.bat
+
+            .. tab-item:: PowerShell
+
+                .. code-block:: text
+
+                    python -m venv .venv
+                    .venv\Scripts\Activate.ps1
+
+    .. tab-item:: Linux/UNIX
+
+        .. code-block:: text
+            python -m venv .venv
+            source .venv/bin/activate
+  
 
 #. Ensure that you have the latest required build system tools:
 
@@ -151,7 +164,7 @@ For building documentation, you can run the usual rules provided in the
     #  build and view the doc from the POSIX system
     make -C doc/ html && your_browser_name doc/html/index.html
 
-    # build and view the doc from CMD / PowerShell environment
+    # build and view the doc from a Windows environment
     .\doc\make.bat clean
     .\doc\make.bat html
     start .\doc\_build\html\index.html

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -10,45 +10,112 @@ with this guide before attempting to contribute to PyMechanical.
  
 The following contribution information is specific to PyMechanical.
 
-Clone the repository
---------------------
-To clone and install the latest version of PyMechanical in
-development mode, run this code:
 
-.. code::
+Install in developer mode
+-------------------------
 
-    git clone https://github.com/pyansys/pymechanical
-    cd pymechanical
-    pip install pip -U
-    pip install -e .
+Installing PyMechanical in developer mode allows
+you to modify the source and enhance it.
 
+.. note::
 
-Post issues
------------
-Use the `PyMechanical Issues <https://github.com/pyansys/pymechanical/issues>`_
-page to submit questions, report bugs, and request new features. When possible,
-use these templates:
+    Before contributing to the project, ensure that you are thoroughly familiar
+    with the `PyAnsys Developer's Guide`_.
 
-* Bug report
-* Feature request
+To install PyMechanical in developer mode, perform these steps:
 
-If your issue does not fit into one of these template categories, create your own issue.
+#. Clone the ``pymechanical`` repository:
 
-To reach the PyAnsys core team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+   .. code:: bash
 
-View documentation
-------------------
-Documentation for the latest stable release of PyMechanical is hosted at
-`PyMechanical Documentation <https://mechanical.docs.pyansys.com>`_.
+      git clone https://github.com/pyansys/pymechanical
 
-Documentation for the latest development version, which tracks the
-``main`` branch, is hosted at `Development PyMechanical Documentation <https://mechanical.docs.pyansys.com/version/dev/index.html>`_.
-This version is automatically kept up to date via GitHub actions.
+#. Access the ``pymechanical`` directory where the repository has been cloned:
+
+   .. code:: bash
+
+      cd pymechanical
+
+#. Create a clean Python virtual environment and activate it:
+
+   .. code:: bash
+
+      # Create a virtual environment
+      python -m venv .venv
+
+      # Activate it in a POSIX system
+      source .venv/bin/activate
+
+      # Activate it in Windows CMD environment
+      .venv\Scripts\activate.bat
+
+      # Activate it in Windows Powershell
+      .venv\Scripts\Activate.ps1
+
+#. Ensure that you have the latest required build system tools:
+
+   .. code:: bash
+
+      python -m pip install -U pip tox flit twine
+
+#. Install the project in editable mode:
+
+   .. code:: bash
+
+      # Install the minimum requirements
+      python -m pip install -e .
+
+      # Install the minimum + tests requirements
+      python -m pip install -e .[tests]
+
+      # Install the minimum + doc requirements
+      python -m pip install -e .[doc]
+
+      # Install all requirements
+      python -m pip install -e .[tests,doc]
+
+#. Verify your development installation:
+
+    .. code:: bash
+
+        tox
+
 
 Test PyMechanical
 -----------------
-If you do not have a licensed copy of Mechanical installed locally but
-want to run PyMechanical unit tests, you must set up environment
+PyMechanical uses `pytest`_ and `tox`_ for unit testing.
+
+Using ``tox``
+^^^^^^^^^^^^^
+This project takes advantage of `tox`_. This tool automates common
+development tasks (similar to Makefile), but it is oriented towards Python
+development.
+
+While Makefile has rules, ``tox`` has environments. In fact, ``tox`` creates its
+own virtual environment so that anything being tested is isolated from the project
+to guarantee the project's integrity.
+
+The following environment commands are provided:
+
+- **tox -e style**: Checks for coding style quality.
+- **tox -e py**: Checks for unit tests.
+- **tox -e py-coverage**: Checks for unit testing and code coverage.
+- **tox -e doc**: Checks for documentation-building process.
+
+
+Raw testing using PyTest
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If required, from the command line, you can call style commands like
+`black`_, `isort`_, and `flake8`_. You can also call unit testing commands like `pytest`_.
+However, running these commands do not guarantee that your project is being tested
+in an isolated environment, which is the reason why tools like ``tox`` exist.
+
+
+Remote Testing
+^^^^^^^^^^^^^^
+If you do not have a licensed copy of Mechanical installed locally but want to
+run PyMechanical unit tests on a remote instance, you must set up environment
 variables.
 
 **On Linux**
@@ -72,6 +139,68 @@ The environment variables for your operating system tell PyMechanical
 to attempt to connect to the existing Mechanical service by default
 when you use the :func:`launch_mechanical() <ansys.mechanical.core.launch_mechanical>`
 method.
+
+
+Documentation
+-------------
+
+For building documentation, you can run the usual rules provided in the
+`Sphinx`_ ``make`` file. Here is an example:
+
+.. code:: bash
+
+    #  build and view the doc from the POSIX system
+    make -C doc/ html && your_browser_name doc/html/index.html
+
+    # build and view the doc from CMD / PowerShell environment
+    .\doc\make.bat clean
+    .\doc\make.bat html
+    start .\doc\_build\html\index.html
+
+
+However, the recommended way of checking documentation integrity is to use
+``tox``:
+
+.. code:: bash
+
+    tox -e doc && your_browser_name .tox/doc_out/index.html
+
+
+Distributing
+------------
+
+If you would like to create either source or wheel files, start by installing
+the building requirements and then executing the build module:
+
+.. code:: bash
+
+    python -m pip install -U pip
+    python -m flit build
+    python -m twine check dist/*
+
+
+Post issues
+-----------
+Use the `PyMechanical Issues <https://github.com/pyansys/pymechanical/issues>`_
+page to submit questions, report bugs, and request new features. When possible,
+use these templates:
+
+* Bug report
+* Feature request
+
+If your issue does not fit into one of these template categories, create your own issue.
+
+To reach the PyAnsys core team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+
+
+View documentation
+------------------
+Documentation for the latest stable release of PyMechanical is hosted at
+`PyMechanical Documentation <https://mechanical.docs.pyansys.com>`_.
+
+Documentation for the latest development version, which tracks the
+``main`` branch, is hosted at `Development PyMechanical Documentation <https://mechanical.docs.pyansys.com/version/dev/index.html>`_.
+This version is automatically kept up to date via GitHub actions.
 
 
 Code style
@@ -98,3 +227,6 @@ This way, it's not possible for you to push code that fails the style checks::
   flake8...................................................................Passed
   codespell................................................................Passed
 
+.. LINKS AND REFERENCES
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _tox: https://tox.wiki/

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -61,6 +61,7 @@ To install PyMechanical in developer mode, perform these steps:
     .. tab-item:: Linux/UNIX
 
         .. code-block:: text
+
             python -m venv .venv
             source .venv/bin/activate
   

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -83,36 +83,35 @@ To install PyMechanical in developer mode, perform these steps:
 
 Test PyMechanical
 -----------------
-PyMechanical uses `pytest`_ and `tox`_ for unit testing.
+PyMechanical uses `PyTest`_ and `tox`_ for unit testing.
 
 Using ``tox``
 ^^^^^^^^^^^^^
-This project takes advantage of `tox`_. This tool automates common
-development tasks (similar to Makefile), but it is oriented towards Python
-development.
+This project takes advantage of `tox`_. This tool automates common development
+tasks (similar to ``Makefile``), but it is oriented towards Python development.
 
-While Makefile has rules, ``tox`` has environments. In fact, ``tox`` creates its
-own virtual environment so that anything being tested is isolated from the project
-to guarantee the project's integrity.
+While ``Makefile`` has rules, ``tox`` has environments. In fact, ``tox``
+creates its own virtual environment so that anything being tested is isolated
+from the project to guarantee the project's integrity.
 
 The following environment commands are provided:
 
-- **tox -e style**: Checks for coding style quality.
-- **tox -e py**: Checks for unit tests.
-- **tox -e py-coverage**: Checks for unit testing and code coverage.
-- **tox -e doc**: Checks for documentation-building process.
+- ``tox -e style``: Checks for coding style quality.
+- ``tox -e py``: Checks for unit tests.
+- ``tox -e py-coverage``: Checks for unit testing and code coverage.
+- ``tox -e doc``: Checks for documentation-building process.
 
 
-Raw testing using PyTest
-^^^^^^^^^^^^^^^^^^^^^^^^
+Without ``tox``
+^^^^^^^^^^^^^^^
 
 If required, from the command line, you can call style commands like
-`black`_, `isort`_, and `flake8`_. You can also call unit testing commands like `pytest`_.
+`black`_, `isort`_, and `flake8`_. You can also call unit testing commands like `PyTest`_.
 However, running these commands do not guarantee that your project is being tested
 in an isolated environment, which is the reason why tools like ``tox`` exist.
 
 
-Remote Testing
+Remote testing
 ^^^^^^^^^^^^^^
 If you do not have a licensed copy of Mechanical installed locally but want to
 run PyMechanical unit tests on a remote instance, you must set up environment
@@ -228,5 +227,5 @@ This way, it's not possible for you to push code that fails the style checks::
   codespell................................................................Passed
 
 .. LINKS AND REFERENCES
-.. _pytest: https://docs.pytest.org/en/stable/
+.. _PyTest: https://docs.pytest.org/en/stable/
 .. _tox: https://tox.wiki/

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -41,3 +41,4 @@ pessimizations
 mutexes
 Addin
 Addins
+isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ doc = [
     "sphinx-autobuild==2021.3.14",
     "sphinx-autodoc-typehints==1.22",
     "sphinx-copybutton==0.5.1",
+    "sphinx_design==0.3.0",
     "sphinx-gallery==0.12.2",
     "sphinx-notfound-page==0.8.3",
     "sphinxcontrib-websupport==1.2.4",


### PR DESCRIPTION
The readme contains a lot of development information. IMO, this is too complex for the average user and it also duplicates much of our web documentation.

Let's simplify this by moving this development information out and into our contributing documentation.

Also updates our runners to use `public-ubuntu-latest-8-cores`.