### PR TITLE
Fix/script return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 -   Include amd folder for mapdl solver in the docker image. (#200)
 -   Remove jscript references from tests/ folder (#205)
 -   Fixes the windows executable path for standalone mechanical (#214)
--   FIX: run_python_script* return empty string for objects that cannot be returned as string (#223)
+-   FIX: run_python_script* return empty string for objects that cannot be returned as string (#224)
 
 ## [0.7.3](https://github.com/pyansys/pymechanical/releases/tag/v0.7.3) - April 20 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 -   Include amd folder for mapdl solver in the docker image. (#200)
 -   Remove jscript references from tests/ folder (#205)
 -   Fixes the windows executable path for standalone mechanical (#214)
+-   FIX: run_python_script* return empty string for objects that cannot be returned as string (#223)
 
 ## [0.7.3](https://github.com/pyansys/pymechanical/releases/tag/v0.7.3) - April 20 2023
 

--- a/examples/00_basic/example_01_simple_structural_solve.py
+++ b/examples/00_basic/example_01_simple_structural_solve.py
@@ -194,8 +194,9 @@ solve_out_path = get_solve_out_path(mechanical)
 if solve_out_path != "":
     current_working_directory = os.getcwd()
 
-    mechanical.download(solve_out_path, target_dir=current_working_directory)
-    solve_out_local_path = os.path.join(current_working_directory, "solve.out")
+    local_file_path_list = mechanical.download(solve_out_path, target_dir=current_working_directory)
+    solve_out_local_path = local_file_path_list[0]
+    print(f"Local solve.out path : {solve_out_local_path}")
 
     write_file_contents_to_console(solve_out_local_path)
 

--- a/examples/00_basic/example_02_capture_images.py
+++ b/examples/00_basic/example_02_capture_images.py
@@ -117,8 +117,11 @@ image_path_server = get_image_path(image_name)
 if image_path_server != "":
     current_working_directory = os.getcwd()
 
-    mechanical.download(image_path_server, target_dir=current_working_directory)
-    image_local_path = os.path.join(current_working_directory, image_name)
+    local_file_path_list = mechanical.download(
+        image_path_server, target_dir=current_working_directory
+    )
+    image_local_path = local_file_path_list[0]
+    print(f"Local image path : {image_local_path}")
 
     display_image(image_local_path)
 

--- a/examples/01_tips_n_tricks/example_01_run_python_script_output.py
+++ b/examples/01_tips_n_tricks/example_01_run_python_script_output.py
@@ -1,10 +1,10 @@
 """.. _ref_example_01_run_python_script_output:
 
-Output to different formats
---------------------------------
+Output to different formats and handle an error
+-----------------------------------------------
 
 This example calls the ``run_python_script`` method and gets the output in string,
-JSON, and CSV formats.
+JSON, and CSV formats. It also handles an error scenario.
 
 """
 
@@ -16,6 +16,8 @@ JSON, and CSV formats.
 # must call  the ``mechanical.exit()`` method.
 
 import json
+
+import grpc
 
 from ansys.mechanical.core import launch_mechanical
 
@@ -74,6 +76,15 @@ return_csv()
 print(f"csv output={output}")
 csv_values = output.split(sep=",")
 print(f"Parsed csv: {';'.join(csv_values)}")
+
+###################################################################################
+# Handle an error scenario
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Run the script and handle the error.
+try:
+    output = mechanical.run_python_script("hello_world()")
+except grpc.RpcError as error:
+    print(f"Error: {error.details()}")
 
 ###########################################################
 # Close Mechanical

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -1844,7 +1844,7 @@ class Mechanical(object):
             ):
                 if enable_logging:
                     self.log_debug(f"Ignoring the conversion error.{error_info}")
-                response = ""
+                response.script_result = ""
             else:
                 raise error
         finally:

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -1834,6 +1834,19 @@ class Mechanical(object):
                 else:
                     if enable_logging:
                         self.log_message(log_level, runscript_response.log_info)
+        except grpc.RpcError as error:
+            error_info = error.details()
+            error_info_lower = error_info.lower()
+            # For the given script, return value cannot be converted to string.
+            if (
+                "the expected result" in error_info_lower
+                and "cannot be return via this API." in error_info
+            ):
+                if enable_logging:
+                    self.log_debug(f"Ignoring the conversion error.{error_info}")
+                response = ""
+            else:
+                raise error
         finally:
             self._busy = False
 

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -1177,10 +1177,10 @@ class Mechanical(object):
             Script result.
         """
         self.verify_valid_connection()
-        response = self.__call_run_python_script(
+        result_as_string = self.__call_run_python_script(
             script_block, enable_logging, log_level, progress_interval
         )
-        return response.script_result
+        return result_as_string
 
     def run_python_script_from_file(
         self, file_path, enable_logging=False, log_level="WARNING", progress_interval=2000
@@ -1823,13 +1823,13 @@ class Mechanical(object):
         request.logger_severity = log_level_server
         request.progress_interval = progress_interval
 
-        response = None
+        result = ""
         self._busy = True
 
         try:
             for runscript_response in self._stub.RunPythonScript(request):
                 if runscript_response.log_info == "__done__":
-                    response = runscript_response
+                    result = runscript_response.script_result
                     break
                 else:
                     if enable_logging:
@@ -1844,7 +1844,7 @@ class Mechanical(object):
             ):
                 if enable_logging:
                     self.log_debug(f"Ignoring the conversion error.{error_info}")
-                response.script_result = ""
+                result = ""
             else:
                 raise error
         finally:
@@ -1852,7 +1852,7 @@ class Mechanical(object):
 
         self._log_mechanical_script(script_code)
 
-        return response
+        return result
 
     def log_message(self, log_level, message):
         """Log the message using the given log level.

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -727,7 +727,16 @@ class Mechanical(object):
 
     @property
     def version(self) -> str:
-        """Get the Mechanical version based on the instance."""
+        """Get the Mechanical version based on the instance.
+
+        Examples
+        --------
+        Get the version of the connected Mechanical instance.
+
+        >>> mechanical.version
+        '231'
+
+        """
         if self._version == None:
             try:
                 self._disable_logging = True
@@ -1158,6 +1167,9 @@ class Mechanical(object):
     ):
         """Run a Python script block inside Mechanical.
 
+        It returns the string value of the last executed statement. If the value cannot be
+        returned as a string, it will return an empty string.
+
         Parameters
         ----------
         script_block : str
@@ -1175,6 +1187,58 @@ class Mechanical(object):
         -------
         str
             Script result.
+
+        Examples
+        --------
+        Return a value from a simple calculation.
+
+        >>> mechanical.run_python_script('2+3')
+        '5'
+
+        Return a string value from Project object.
+
+        >>> mechanical.run_python_script('ExtAPI.DataModel.Project.ProductVersion')
+        '2023 R1'
+
+        Return an empty string, when you try to return the Project object.
+
+        >>> mechanical.run_python_script('ExtAPI.DataModel.Project')
+        ''
+
+        Return an empty string for assignments.
+
+        >>> mechanical.run_python_script('version = ExtAPI.DataModel.Project.ProductVersion')
+        ''
+
+        Return value from the last executed statement from a variable.
+
+        >>> script='''
+            addition = 2 + 3
+            multiplication = 3 * 4
+            multiplication
+            '''
+        >>> mechanical.run_python_script(script)
+        '12'
+
+        Return value from last executed statement from a function call.
+
+        >>> script='''
+            import math
+            math.pow(2,3)
+            '''
+        >>> mechanical.run_python_script(script)
+        '8'
+
+        Handle an error scenario.
+
+        >>> script = 'hello_world()'
+        >>> import grpc
+        >>> try:
+                mechanical.run_python_script(script)
+            except grpc.RpcError as error:
+                print(error.details())
+        name 'hello_world' is not defined
+
         """
         self.verify_valid_connection()
         result_as_string = self.__call_run_python_script(
@@ -1185,7 +1249,10 @@ class Mechanical(object):
     def run_python_script_from_file(
         self, file_path, enable_logging=False, log_level="WARNING", progress_interval=2000
     ):
-        """Run a Python file inside Mechanical.
+        """Run the contents a python file inside Mechanical.
+
+        It returns the string value of the last executed statement. If the value cannot be
+        returned as a string, it will return an empty string.
 
         Parameters
         ----------
@@ -1204,6 +1271,29 @@ class Mechanical(object):
         -------
         str
             Script result.
+
+        Examples
+        --------
+        Return a value from a simple calculation.
+
+        Contents of **simple.py** file
+
+        2+3
+
+        >>> mechanical.run_python_script('simple.py')
+        '5'
+
+        Return a value from a simple function call.
+
+        Contents of  **test.py** file
+
+        import math
+
+        math.pow(2,3)
+
+        >>> mechanical.run_python_script('test.py')
+        '8'
+
         """
         self.verify_valid_connection()
         self.log_debug(f"run_python_script_from_file started")
@@ -1220,6 +1310,13 @@ class Mechanical(object):
             Whether to force Mechanical to exit. The default is ``False``, in which case
             only Mechanical in UI mode asks for confirmation. This parameter overrides
             any environment variables that may inhibit exiting Mechanical.
+
+        Examples
+        --------
+        Exit Mechanical.
+
+        >>> mechanical.Exit(force=True)
+
         """
         if not force:
             if not get_start_instance():
@@ -1388,7 +1485,16 @@ class Mechanical(object):
 
     @property
     def project_directory(self):
-        """Get the project directory for the currently connected Mechanical instance."""
+        """Get the project directory for the currently connected Mechanical instance.
+
+        Examples
+        --------
+        Get the project directory of the connected Mechanical instance.
+
+        >>> mechanical.project_directory
+        '/tmp/ANSYS.username.1/AnsysMech3F97/Project_Mech_Files/'
+
+        """
         return self.run_python_script("ExtAPI.DataModel.Project.ProjectDirectory")
 
     def list_files(self):
@@ -1401,6 +1507,8 @@ class Mechanical(object):
 
         Examples
         --------
+        List the files in the working directory.
+
         >>> files = mechanical.list_files()
         >>> for file in files: print(file)
         """
@@ -1483,6 +1591,9 @@ class Mechanical(object):
     ):  # pragma: no cover
         """Download files from the working directory of the Mechanical instance.
 
+         It downloads them from the working directory to the target directory. It returns the list
+         of local file paths for the downloaded files.
+
         Parameters
         ----------
         files : str, list[str], tuple(str)
@@ -1493,7 +1604,8 @@ class Mechanical(object):
             match file names. For example, you could use ``file*`` to match every file whose
             name starts with ``file``.
         target_dir: str
-            Default directory to copy the downloaded files to. The default is ``None``.
+            Default directory to copy the downloaded files to. The default is ``None`` and
+            current working directory will be used as target directory.
         chunk_size : int, optional
             Chunk size in bytes. The default is ``262144``. The value must be less than 4 MB.
         progress_bar : bool, optional
@@ -1502,6 +1614,11 @@ class Mechanical(object):
             progress.
         recursive : bool, optional
             Whether to use recursion when using a glob pattern search. The default is ``False``.
+
+        Returns
+        -------
+        List[str]
+            List of local file paths.
 
         Notes
         -----
@@ -1517,21 +1634,21 @@ class Mechanical(object):
         --------
         Download a single file.
 
-        >>> mechanical.download('file.out')
+        >>> local_file_path_list = mechanical.download('file.out')
 
         Download all files starting with ``file``.
 
-        >>> mechanical.download('file*')
+        >>> local_file_path_list = mechanical.download('file*')
 
         Download every file in the Mechanical working directory.
 
-        >>> mechanical.download('*.*')
+        >>> local_file_path_list = mechanical.download('*.*')
 
         Alternatively, the recommended method is to use the
         :func:`download_project() <ansys.mechanical.core.mechanical.Mechanical.download_project>`
         method to download all files.
 
-        >>> mechanical.download_project()
+        >>> local_file_path_list = mechanical.download_project()
 
         """
         self.verify_valid_connection()
@@ -1687,6 +1804,9 @@ class Mechanical(object):
     def download_project(self, extensions=None, target_dir=None, progress_bar=False):
         """Download all project files in the working directory of the Mechanical instance.
 
+        It downloads them from the working directory to the target directory. It returns the list
+        of local file paths for the downloaded files.
+
         Parameters
         ----------
         extensions : list[str], tuple[str], optional
@@ -1701,7 +1821,14 @@ class Mechanical(object):
         Returns
         -------
         List[str]
-            List of downloaded files.
+            List of local file paths.
+
+        Examples
+        --------
+        Download all the files in the project.
+
+        >>> local_file_path_list = mechanical.download_project()
+
         """
         destination_directory = target_dir.rstrip("\\/")
 
@@ -1769,7 +1896,15 @@ class Mechanical(object):
         return list_of_files
 
     def clear(self):
-        """Clear the database."""
+        """Clear the database.
+
+        Examples
+        --------
+        Clear the database.
+
+        >>> mechanical.clear()
+
+        """
         self.run_python_script("ExtAPI.DataModel.Project.New()")
 
     def _make_dummy_call(self):
@@ -1846,7 +1981,7 @@ class Mechanical(object):
                     self.log_debug(f"Ignoring the conversion error.{error_info}")
                 result = ""
             else:
-                raise error
+                raise
         finally:
             self._busy = False
 
@@ -1864,6 +1999,17 @@ class Mechanical(object):
             and ``"ERROR"``.
         message : str
             Message to log.
+
+        Examples
+        --------
+        Log a debug message.
+
+        >>> mechanical.log_message('DEBUG', 'debug message')
+
+        Log an info message.
+
+        >>> mechanical.log_message('INFO', 'info message')
+
         """
         if log_level == "DEBUG":
             self.log_debug(message)

--- a/src/ansys/mechanical/core/pool.py
+++ b/src/ansys/mechanical/core/pool.py
@@ -673,7 +673,16 @@ class LocalMechanicalPool:
 
     @property
     def ports(self):
-        """Get a list of the ports that are used."""
+        """Get a list of the ports that are used.
+
+        Examples
+        --------
+        Get the list of ports used by the pool of Mechanical instances.
+
+        >>> pool.ports
+        [10001, 10002]
+
+        """
         return [inst._port for inst in self if inst is not None]
 
     def __str__(self):

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -19,6 +19,12 @@ def test_run_python_script_success(mechanical):
 
 
 @pytest.mark.remote_session_connect
+def test_run_python_script_success_return_empty(mechanical):
+    result = mechanical.run_python_script("ExtAPI.DataModel.Project")
+    assert result == ""
+
+
+@pytest.mark.remote_session_connect
 def test_run_python_script_error(mechanical):
     with pytest.raises(grpc.RpcError) as exc_info:
         mechanical.run_python_script("import test")
@@ -199,8 +205,11 @@ return_total_deformation()
     if solve_out_path != "":
         print(f"downloading {solve_out_path} from server")
         print(f"downloading to {current_working_directory}")
-        mechanical.download(solve_out_path, target_dir=current_working_directory)
-        solve_out_local_path = os.path.join(current_working_directory, "solve.out")
+        solve_out_local_path_list = mechanical.download(
+            solve_out_path, target_dir=current_working_directory
+        )
+        solve_out_local_path = solve_out_local_path_list[0]
+        print(solve_out_local_path)
 
         write_file_contents_to_console(solve_out_local_path)
 
@@ -329,12 +338,13 @@ def verify_download(mechanical, tmpdir, file_name, chunk_size):
     local_directory = tmpdir.strpath
 
     # test with different download chunk_size
-    mechanical.download(files=file_path, target_dir=local_directory, chunk_size=chunk_size)
-
-    base_name = os.path.basename(file_path)
-    local_path = os.path.join(local_directory, base_name)
-
-    assert os.path.exists(local_path) and os.path.getsize(local_path) > 0
+    local_path_list = mechanical.download(
+        files=file_path, target_dir=local_directory, chunk_size=chunk_size
+    )
+    print("downloaded files:")
+    for local_path in local_path_list:
+        print(f" downloaded file: {local_path}")
+        assert os.path.exists(local_path) and os.path.getsize(local_path) > 0
 
 
 @pytest.mark.remote_session_connect

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -21,7 +21,10 @@ def test_run_python_script_success(mechanical):
 @pytest.mark.remote_session_connect
 def test_run_python_script_success_return_empty(mechanical):
     result = mechanical.run_python_script("ExtAPI.DataModel.Project")
-    assert result == ""
+    if misc.is_windows():
+        assert result == ""
+    else:
+        assert result == "Ansys.ACT.Automation.Mechanical.Project"
 
 
 @pytest.mark.remote_session_connect


### PR DESCRIPTION
This fixes the issue #207. 

Return empty string when the run_python_script* return value cannot be converted to a string.

Other changes:
Update examples to use the return value from .download()
Add an error handling step in an example
Add example code for many APIs
