### PR TITLE
added pythonnet check with warning output

### DIFF
--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -2,6 +2,9 @@
 import atexit
 import os
 import typing
+import warnings
+
+from pip._internal.operations import freeze
 
 from ansys.mechanical.core.embedding import initializer, runtime
 from ansys.mechanical.core.embedding.config import Configuration, configure
@@ -71,6 +74,19 @@ class App:
         if self._version == None:
             self._version = _get_default_version()
         initializer.initialize(self._version)
+
+        pkgs = freeze.freeze()
+        for pkg in pkgs:
+            indx = pkg.index("=")
+            if pkg[:indx] == "pythonnet":
+                warnings.warn(
+                    "The pythonnet package was found in your environment"
+                    "which interferes with the ansys-pythonnet package. "
+                    "Some APIs may not work due to pythonnet being installed.",
+                    stacklevel=3,
+                )
+                break
+
         import clr
 
         clr.AddReference("Ansys.Mechanical.Embedding")

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -78,6 +78,7 @@ class App:
             self._version = _get_default_version()
         initializer.initialize(self._version)
 
+        # Check if 'pythonnet' is installed... and if so, throw warning
         pkgs = freeze.freeze()
         for pkg in pkgs:
             indx = pkg.index("=")

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -4,7 +4,10 @@ import os
 import typing
 import warnings
 
-from pip._internal.operations import freeze
+try:
+    from pip._internal.operations import freeze
+except ImportError: # pip < 10.0
+    from pip.operations import freeze
 
 from ansys.mechanical.core.embedding import initializer, runtime
 from ansys.mechanical.core.embedding.config import Configuration, configure


### PR DESCRIPTION
If pythonnet is installed and a remote instance is used, there should not be a warning. Pymechanical embedding should work, but some of the APIs will not work if pythonnet is installed. Since the remote instance should still work whether or not pythonnet is installed, it was determined a warning would be a better use, so users are aware of the conflict, but it doesn't stop it from running.